### PR TITLE
Adds clarity to README that NPM is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Make sure to check out [`electron-webpack`'s documentation](https://webpack.elec
 ## Getting Started
 Simply clone down this reposity, install dependencies, and get started on your application.
 
-The use of the [yarn](https://yarnpkg.com/) package manager is **strongly** recommended, as opposed to using `npm`.
+The [yarn](https://yarnpkg.com/) package manager is **required** to use this quick-start, as opposed to `npm`.
 
 ```bash
 # create a directory of your choice, and copy template using curl


### PR DESCRIPTION
I'm worried that future developers will see the warning about `yarn` being "recommended", but won't realize that the `quick-start` won't work _at all_ if `npm` is used instead of `yarn`