### PR TITLE
defer openDevTools until frame is loaded

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -13,10 +13,15 @@ function createMainWindow() {
   const window = new BrowserWindow()
 
   if (isDevelopment) {
-    window.webContents.openDevTools()
-  }
-
-  if (isDevelopment) {
+    window.webContents.on('devtools-opened', () => {
+      window.focus()
+      setImmediate(() => {
+        window.focus()
+      })
+    })    
+    window.webContents.on('did-frame-finish-load', () => {   
+      window.webContents.openDevTools();
+    })
     window.loadURL(`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}`)
   }
   else {
@@ -29,13 +34,6 @@ function createMainWindow() {
 
   window.on('closed', () => {
     mainWindow = null
-  })
-
-  window.webContents.on('devtools-opened', () => {
-    window.focus()
-    setImmediate(() => {
-      window.focus()
-    })
   })
 
   return window


### PR DESCRIPTION
As discussed in [here](https://github.com/SimulatedGREG/electron-vue/issues/389), when `openDevTools()` is called too soon, an `"Extension server error: Object not found: <top>"` error is reported. 
The linked issue discusses a couple of approaches to defer that call.

This PR uses a `'did-frame-finish-load'` event listener to invoke `openDevTools()`.