### PR TITLE
Support NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "electron-webpack dev",
     "compile": "electron-webpack",
-    "dist": "yarn compile && electron-builder",
-    "dist:dir": "yarn dist --dir -c.compression=store -c.mac.identity=null"
+    "dist": "npm run compile && electron-builder",
+    "dist:dir": "npm run dist --dir -c.compression=store -c.mac.identity=null"
   },
   "dependencies": {
     "source-map-support": "^0.5.12"


### PR DESCRIPTION
As is, the messages that "yarn is recommended" are misleading. This PR solves the issue by supporting NPM.

This shouldn't be a breaking change, as Yarn is backwards compatible with scripts written using NPM.